### PR TITLE
Labels: Remove databases as a platform and update macOS case

### DIFF
--- a/github_labels.md
+++ b/github_labels.md
@@ -53,11 +53,10 @@
 
  - AWS
  - Azure
- - Databases
  - Docker
  - GCP
  - Linux
- - MacOS
+ - macOS
  - UNIX-like
  - VMware
  - Windows


### PR DESCRIPTION
This doesn't seem like a platform. It also seems like something that is pretty InSpec specific vs. all the other projects. It should be added to just InSpec.

Also macOS has a lowercase m because Apple is too cool.