### PR TITLE
Labels: Add priority labels

### DIFF
--- a/github_labels.md
+++ b/github_labels.md
@@ -62,6 +62,12 @@
  - VMware
  - Windows
 
+ ## Priority
+ 
+ - Low
+ - Medium
+ - Critical
+
  ## Size
 
  Setting a size on Pull Requests helps reviewers manage their time.


### PR DESCRIPTION
We use this extensively in Chef as part of the triage to try to prioritize our work since we can't fix all the bugs that come in.