### PR TITLE
Add `Waiting on Contributor` GitHub label

### DIFF
--- a/github_labels.md
+++ b/github_labels.md
@@ -62,7 +62,7 @@
  - Windows
 
  ## Priority
- 
+
  - Low
  - Medium
  - Critical
@@ -92,6 +92,8 @@
    An issue that has enough details to be started.
  - Incomplete
    A pull request that is not ready to be merged as noted by the author.
+ - Waiting on Contributor
+   A pull request that has unresolved requested actions from the author.
 
  ## Triage
 


### PR DESCRIPTION
Example use case:

Author has submitted a PR, but the maintainer cannot merge until some action is completed by the author (e.g. needs tests or corrections).