### PR TITLE
Add descriptions to labels.

### DIFF
--- a/github_labels.md
+++ b/github_labels.md
@@ -24,9 +24,7 @@ Projects in the Chef Community should feel encouraged to use these labels in the
  - `Security` Can an unwanted third party affect the stability or look at privileged information?
  - `Stability` Consistent results.
  - `Testing` Does the project have good coverage, and is CI working?
- - `UX` Affects how users feel about interacting with your project.
- - `UI` Affects how users interact with your project.
-
+ 
 ## Expeditor
 
  If your project is using Expeditor you'll want these labels.


### PR DESCRIPTION
I've added descriptions to the majority of the labels. I also reformatted the layout a bit and made the labels stand out as `inline code`.

Signed-off-by: Miah Johnson <miah@chia-pet.org>

resolves https://github.com/chef/chef-oss-practices/issues/32