### PR TITLE
Shuffle around multiple labels

### DIFF
--- a/github_labels.md
+++ b/github_labels.md
@@ -80,7 +80,7 @@ Projects in the Chef Community should feel encouraged to use these labels in the
  - `Not Reproducible` Indicates an issue can not be reproduced as described.
  - `Support` Indicates an issue that is a support question and will be redirected to other mediums.
  - `Declined` Indicates an issue that can not or will not be resolved.
- - `Feature Request` Indicats an issue requesting new functionality.
+ - `Feature Request` Indicates an issue requesting new functionality.
 
 ## Type
 


### PR DESCRIPTION
I noted which categories are appropriate for PRs and which are appropriate for issues
I added the new Expeditor: Bump Version Major label now that Expeditor can perform major version bumps
I shuffled things around in status and merged the help categories into status. These indicate where things are in resolving an issue. Is something already working on it. Do we want community members to grab it. Is it ideal for a new contributor.
Feature request was moved from type into triage since it's a label we set on issues during triage. I also removed the type of question since we already had that covered under triage as well. If someone opens a question we're going to close it out with a canned response redirecting them to Slack / Discourse.