### PR TITLE
opt out of DCO checking on this repo

### DIFF
--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -1,0 +1,3 @@
+---
+github:
+  enforce_dco_signoff: false


### PR DESCRIPTION
## Description
This repository is documentation not code and so does not require DCO sign-offs from contributors. Adds a configuration for Expeditor to opt out of the DCO check when the bot takes over performing that check.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- ~Bug fix (non-breaking change which fixes an issue)~
- [x] New content (non-breaking change)
- ~Breaking change (a content change which would break existing functionality or processes)~

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
