### PR TITLE
Add a new default label of "status: untriaged"

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -1,7 +1,7 @@
 ---
 name: Bug Report
 about: Explain how the Chef Software Open Source Communities documentation is incorrect
-labels: 'Type: Bug'
+labels: 'Type: Bug', 'Status: Untriaged'
 ---
 
 <!--- Provide a general summary of the issue in the Title above -->

--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -1,7 +1,7 @@
 ---
 name: Feature Request
 about: Request new content for Chef Software Open Source Communities repo
-labels: 'Triage: Feature Request'
+labels: 'Triage: Feature Request', 'Status: Untriaged'
 ---
 
 <!--- Provide a general summary of the requested feature in the Title above. -->

--- a/.github/ISSUE_TEMPLATE/membership.md
+++ b/.github/ISSUE_TEMPLATE/membership.md
@@ -2,7 +2,7 @@
 name: Project Membership Request
 about: Request membership in a Chef Software Inc. OSS project
 title: 'REQUEST: New membership for <your-GH-handle>'
-labels:
+labels: 'Status: Untriaged'
 assignees: ''
 
 ---

--- a/repo-management/github-labels.md
+++ b/repo-management/github-labels.md
@@ -71,6 +71,7 @@ Projects in the Chef Community should feel encouraged to use these labels in the
 
 ## Status
 
+ - `Untriaged` An issue that has yet to be triaged. This should be set on all new issues
  - `Adopted` An issue that is being worked on.
  - `Incomplete` A pull request that is not ready to be merged as noted by the author.
  - `Waiting on Contributor` An issue or pull request that has unresolved requested actions from the author.


### PR DESCRIPTION
Everything will get this label applied via the templates and then we'll take it off as we triage. This makes it super easy to track what has yet to be triaged.

Signed-off-by: Tim Smith <tsmith@chef.io>