### PR TITLE
reword and link blurb about repo states

### DIFF
--- a/repo-management/repo-states.md
+++ b/repo-management/repo-states.md
@@ -30,5 +30,5 @@ Both the Project State and SLAs must be defined in the README of the project. We
 * **Issues Response SLA: 3 business days**
 * **Pull Request Response SLA: 3 business days**
 
-For more information on project states and SLAs, see [this documentation](https://github.com/chef/chef-oss-practices/blob/master/repo-management/repo-states.md)
+See [Chef's documentation on open source practices](https://github.com/chef/chef-oss-practices) for more [information about projects states and SLAs](https://github.com/chef/chef-oss-practices/blob/master/repo-management/repo-states.md).
 ```


### PR DESCRIPTION
## Description

Because `click <here>` makes my brain itch.

Results in a sentence that looks like:

> See [Chef's documentation on open source practices](https://github.com/chef/chef-oss-practices) for more [information about projects states and SLAs](https://github.com/chef/chef-oss-practices/blob/master/repo-management/repo-states.md).