### PR TITLE
remove section header anchors from links

### DIFF
--- a/repo-management/repo-states.md
+++ b/repo-management/repo-states.md
@@ -27,6 +27,6 @@ Both the Project State and Response Time Maximums must be defined in the README 
 
 ```
 * **[Project State](https://github.com/chef/chef-oss-practices/blob/master/repo-management/repo-states.md): Active**
-* **Issues [Response Time Maximum](https://github.com/chef/chef-oss-practices/blob/master/repo-management/repo-states.md#what-is-the-response-time-maximum): 7 days**
-* **Pull Request [Response Time Maximum](https://github.com/chef/chef-oss-practices/blob/master/repo-management/repo-states.md#what-is-the-response-time-maximum): 7 days**
+* **Issues [Response Time Maximum](https://github.com/chef/chef-oss-practices/blob/master/repo-management/repo-states.md): 7 days**
+* **Pull Request [Response Time Maximum](https://github.com/chef/chef-oss-practices/blob/master/repo-management/repo-states.md): 7 days**
 ```


### PR DESCRIPTION
Let's send everyone to the repo-states page instead so that links back here don't break if the sections change.