### PR TITLE
Remove core repo from Habitat project

### DIFF
--- a/projects/habitat.md
+++ b/projects/habitat.md
@@ -50,5 +50,4 @@ Matt Peck
 ### Project Repositories
 
 - [habitat](https://github.com/habitat-sh/habitat)
-- [habitat-core](https://github.com/habitat-sh/core)
 - [homebrew-habitat](https://github.com/habitat-sh/homebrew-habitat)


### PR DESCRIPTION
Since the core repo has been merged into the habitat repo, we don't need a specific entry for it

Signed-off-by: Salim Alam <salam@chef.io>