### PR TITLE
[Chef Workstation Project] Make me Owner & add chef-analyze repository

### DIFF
--- a/projects/chef-workstation.md
+++ b/projects/chef-workstation.md
@@ -22,15 +22,15 @@ Mike Krasnow
   - Github: [krasnow](https://github.com/krasnow)
   - Slack: @krasnow
 
+Salim Afiune
+  - Github: [afiune](https://github.com/afiune)
+  - Slack: @afiune
+
 #### Project Approvers
 
 Robb Kidd
   - Github: [robbkidd](https://github.com/robbkidd)
   - Slack: @robbkidd
-
-Salim Afiune
-  - Github: [afiune](https://github.com/afiune)
-  - Slack: @afiune
 
 Tim Smith
   - Github: [tas50](https://github.com/tas50)

--- a/projects/chef-workstation.md
+++ b/projects/chef-workstation.md
@@ -50,4 +50,5 @@ Tyler Ball
 - [chef-workstation-app](https://github.com/chef/chef-workstation-app)
 - [cookstyle](https://github.com/chef/cookstyle)
 - [chef-cli](https://github.com/chef/chef-cli)
+- [chef-analyze](https://github.com/chef/chef-analyze)
 - [cookbook-omnifetch](https://github.com/chef/cookbook-omnifetch)


### PR DESCRIPTION
## Description
1) I would like to be an owner of the Chef Workstation project.
2) Adds [chef-analyze](https://github.com/chef/chef-analyze) as a Chef Workstation project repository.

## Related Issue
N/A

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
- [X] I have read the **CONTRIBUTING** document.
