### PR TITLE
Add vscode-chef to the chef-workstation project

### DIFF
--- a/projects/chef-workstation.md
+++ b/projects/chef-workstation.md
@@ -1,6 +1,6 @@
 # Chef Workstation Project
 
-The Chef Workstataion project includes Chef Workstation, Chef-DK, and all related repositories.
+The Chef Workstataion project includes Chef Workstation, ChefDK, and all related repositories.
 
 **Slack Channel** #chef-workstation-dev
 
@@ -52,3 +52,4 @@ Tyler Ball
 - [chef-cli](https://github.com/chef/chef-cli)
 - [chef-analyze](https://github.com/chef/chef-analyze)
 - [cookbook-omnifetch](https://github.com/chef/cookbook-omnifetch)
+- [vscode-chef](https://github.com/chef/vscode-chef)


### PR DESCRIPTION
This is a new repo in the Chef org, but a very important part of the
overall goal of making it easier to use chef tooling, stay current, and
migrate to new workflows. We can nudge folks that right way through
their authoring of cookbook or other Chef code.

Signed-off-by: Tim Smith <tsmith@chef.io>