### PR TITLE
Add chef-community-zero to the Supermarket project

### DIFF
--- a/projects/supermarket.md
+++ b/projects/supermarket.md
@@ -43,3 +43,4 @@ Will Fisher
 - [supermarket](https://github.com/chef/supermarket)
 - [supermarket-omnibus-cookbook](https://github.com/chef-cookbooks/supermarket-omnibus-cookbook)
 - [cookbook-quality-metrics](https://github.com/chef-cookbooks/cookbook-quality-metrics)
+- [chef-community-zero](https://github.com/chef/chef-community-zero)


### PR DESCRIPTION
This is a dep for stove. Seemed appropriate to add it to the Supermarket
project as it's used for emulating the supermarket API in local testing

Signed-off-by: Tim Smith <tsmith@chef.io>