### PR TITLE
Add chef-api to the Chef Infra project

### DIFF
--- a/projects/chef-infra.md
+++ b/projects/chef-infra.md
@@ -36,8 +36,9 @@ Mark Anderson
 
 ### Project Repositories
 
-- [chef](https://github.com/chef/chef)
-- [ohai](https://github.com/chef/ohai)
 - [bft](https://github.com/chef/bft)
+- [chef](https://github.com/chef/chef)
 - [cheffish](https://github.com/chef/cheffish)
+- [chef-api](https://github.com/chef/chef-api)
+- [ohai](https://github.com/chef/ohai)
 - [proxy_tests](https://github.com/chef/proxy_tests)


### PR DESCRIPTION
This is a dep of stove (for now) and seemed appropriate here. If we
remove this from stove then we can deprecate the project and remove it
from this list, but for now we need to maintain it.

Signed-off-by: Tim Smith <tsmith@chef.io>