### PR TITLE
Remove the size labels

### DIFF
--- a/repo-management/github-labels.md
+++ b/repo-management/github-labels.md
@@ -58,17 +58,6 @@ Projects in the Chef Community should feel encouraged to use these labels in the
  - `Medium`
  - `Critical`
 
-## Size
-
- Setting a size on Pull Requests helps reviewers manage their time.
-
- - `XS` - A PR that changes 0-9 lines, ignoring generated files.
- - `S` - A PR that changes 10-29 lines, ignoring generated files.
- - `M` - A PR that changes 30-99 lines, ignoring generated files.
- - `L` - A PR that changes 100-499 lines, ignoring generated files.
- - `XL` - A PR that changes 500-999 lines, ignoring generated files.
- - `XXL` - A PR that changes 1000+ lines, ignoring generated files.
-
 ## Status
 
  - `Adopted` - An issue that is being worked on.


### PR DESCRIPTION
I'd like to propose we remove the size labels. Without automation these
aren't adding anything to our process and just make it harder to find
the valid labels in the list.

Signed-off-by: Tim Smith <tsmith@chef.io>