### PR TITLE
Remove the correctness aspect label

### DIFF
--- a/repo-management/github-labels.md
+++ b/repo-management/github-labels.md
@@ -16,7 +16,6 @@ Projects in the Chef Community should feel encouraged to use these labels in the
 
  Aspects define the characteristics of an issue.
 
- - `Correctness` - Does the implementation match the specification?
  - `Documentation` - How do we use this project?
  - `Integration` - Works correctly with other projects or systems.
  - `Packaging` - Distribution of the projects "compiled" artifacts.


### PR DESCRIPTION
Everything is "correctness" so this is being applied to just about
everything in triage and isn't helpful. If aspect maps to the old
"component" labels in projects we should try to keep it focused and not
broad enough that it applies to nearly 100% of the issues / PRs

Signed-off-by: Tim Smith <tsmith@chef.io>