### PR TITLE
Add new team members to habitat approvers

### DIFF
--- a/projects/builder.md
+++ b/projects/builder.md
@@ -21,11 +21,14 @@ Salim Alam
 Christopher Maier
   - Github: [christophermaier](https://github.com/christophermaier)
 
-Jon Bauman
-  - Github: [baumanj](https://github.com/baumanj)
+Jeremy Miller
+  - Github: [jeremymv2](https://github.com/jeremymv2)
 
 Josh Black
   - Github: [raskchanky](https://github.com/raskchanky)
+
+Mark Anderson
+  - Github: [markan](https://github.com/markan)
 
 #### Project Reviewers
 
@@ -37,9 +40,6 @@ Liz Chen
 
 Mary Jinglewski
   - Github: [mjingle](https://github.com/mjingle)
-
-Matt Peck
-  - Github: [mpeck](https://github.com/mpeck)
 
 Matt Wrock
   - Github: [mwrock](https://github.com/mwrock)

--- a/projects/habitat.md
+++ b/projects/habitat.md
@@ -13,19 +13,23 @@ Includes all code for the Habitat Supervisor, CLI, Studio, exporters, etc.
 Christopher Maier
   - Github: [christophermaier](https://github.com/christophermaier)
 
-Jon Bauman
-  - Github: [baumanj](https://github.com/baumanj)
-
 #### Project Approvers
+
+Jeremy Miller
+  - Github: [jeremymv2](https://github.com/jeremymv2)
 
 Josh Black
   - Github: [raskchanky](https://github.com/raskchanky)
+
+Mark Anderson
+  - Github: [markan](https://github.com/markan)
 
 Matt Wrock
   - Github: [mwrock](https://github.com/mwrock)
 
 Salim Alam
   - Github: [chefsalim](https://github.com/chefsalim)
+
 
 #### Project Reviewers
 
@@ -40,9 +44,6 @@ Liz Chen
 
 Mary Jinglewski
   - Github: [mjingle](https://github.com/mjingle)
-
-Matt Peck
-  - Github: [mpeck](https://github.com/mpeck)
 
 Scott Hain
   - Github: [scotthain](https://github.com/scotthain)


### PR DESCRIPTION
## Description

Jeremy Miller and Mark Anderson have joined the Habitat team. Jon
Bauman and Matt Peck are no longer working on Habitat. This updates
the builder and habitat team lists to match.

Signed-off-by: Mark Anderson <mark@chef.io>

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.