### PR TITLE
Minor update to link README.md #table-of-contents

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Welcome to the Chef Software Open Source communities!
 
 This is a starting point for contributing to all of Chef's software and a wonderful spot for information on how to join in on the fun.
 
-Looking for something specific? Check out our [Table of Contents](table-of-contents.md).
+Looking for something specific? Check out our [Table of Contents](#table-of-contents).
 
 To learn more about each of our project's structure and organization, please refer to [Governance](governance.md).
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail, what problems does it solve? -->
Link https://github.com/chef/chef-oss-practices/blob/master/table-of-contents.md of "Table of Contents" directed to `404`, If I am not wrong I think we would have pointed to https://github.com/chef/chef-oss-practices#table-of-contents.

So assuming it should point to root README.md "Table of Contents" itself.

Signed-off-by: Vivek Singh <vivek.singh@msystechnologies.com>