### PR TITLE
change readme file links to absolute links

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,11 +8,11 @@ Welcome to the Chef Software Open Source communities!
 
 This is a starting point for contributing to all of Chef's software and a wonderful spot for information on how to join in on the fun.
 
-Looking for something specific? Check out our [Table of Contents](table-of-contents.md).
+Looking for something specific? Check out our [Table of Contents](https://github.com/chef/chef-oss-practices/blob/master/table-of-contents.md).
 
-To learn more about each of our project's structure and organization, please refer to [Governance](governance.md).
+To learn more about each of our project's structure and organization, please refer to [Governance](https://github.com/chef/chef-oss-practices/blob/master/governance.md).
 
-We are currently rolling out these processes to all of Chef's Open Source projects in stages and will be iterating as we go - we would love you to [contribute](CONTRIBUTING.md)!
+We are currently rolling out these processes to all of Chef's Open Source projects in stages and will be iterating as we go - we would love you to [contribute](https://github.com/chef/chef-oss-practices/blob/master/CONTRIBUTING.md)!
 
 ## Inspiration
 
@@ -22,88 +22,88 @@ The practices in this repo are inspired by [Adam Jacob's book on Free and Sustai
 
 Chef Software (the company) produces many products such as Chef, InSpec, Habitat, and Automate. Each of these products is fully open source and comprised of one or more open source projects. For instance, the Chef product is comprised of chef, ohai, various mixlib projects, and other interdependent libraries. The project and/or sub-project scope is defined in the README.md file in each individual project's GitHub repository.
 
-All Chef projects operate under governance determined by the Chef OSS Practices Committee. These policies are documented under [Governance](governance.md); however, *Teams* can have their own [policy for contribution](repo-management/project-required-setup.md#CONTRIBUTING.md), communication standards, etc. so long as those policies meet the base governance policy.
+All Chef projects operate under governance determined by the Chef OSS Practices Committee. These policies are documented under [Governance](https://github.com/chef/chef-oss-practices/blob/master/governance.md); however, *Teams* can have their own [policy for contribution](repo-management/project-required-setup.md#CONTRIBUTING.md), communication standards, etc. so long as those policies meet the base governance policy.
 
-We decide on the long term plan for projects through [Project planning](contributors/guide/project-planning.md) and our [triage and prioritization](contributors/guide/issue-triage.md) processes.
+We decide on the long term plan for projects through [Project planning](https://github.com/chef/chef-oss-practices/blob/master/contributors/guide/project-planning.md) and our [triage and prioritization](https://github.com/chef/chef-oss-practices/blob/master/contributors/guide/issue-triage.md) processes.
 
 ## Communicating With Us
 
-The [communication](communication/README.md) page lists communications channels such as chat, GitHub issues, mailing lists, conferences, etc.
+The [communication](https://github.com/chef/chef-oss-practices/blob/master/communication/README.md) page lists communications channels such as chat, GitHub issues, mailing lists, conferences, etc.
 
 For more detailed information, check the README.md in a project's repository.
 
 ## Getting Started Contributing
 
-A first step towards contributing is to pick from the [list of Chef Software Projects](projects-list.md).
+A first step towards contributing is to pick from the [list of Chef Software Projects](https://github.com/chef/chef-oss-practices/blob/master/projects-list.md).
 
 Once you've selected a project to contribute to, be sure to read the team's contribution guide (CONTRIBUTING.md). That guide will provide information on issues in need of contributors, team meetings schedules, and Slack channels / mailing lists where project discussions take place.
 
-The [Contributor Guide](contributors/guide/README.md) provides detailed instructions on how to get your code accepted to Chef Software projects, including:
+The [Contributor Guide](https://github.com/chef/chef-oss-practices/blob/master/contributors/guide/README.md) provides detailed instructions on how to get your code accepted to Chef Software projects, including:
 
-  1. How to [file an issue](contributors/guide/README.md#file-an-issue)
-  2. How to [find something to work on](contributors/guide/README.md#find-something-to-work-on)
-  3. How to [open a pull request](contributors/guide/README.md#open-a-pull-request)
+  1. How to [file an issue](https://github.com/chef/chef-oss-practices/blob/master/contributors/guide/README.md#file-an-issue)
+  2. How to [find something to work on](https://github.com/chef/chef-oss-practices/blob/master/contributors/guide/README.md#find-something-to-work-on)
+  3. How to [open a pull request](https://github.com/chef/chef-oss-practices/blob/master/contributors/guide/README.md#open-a-pull-request)
 
 ## Creating a New Chef Open Source Project
 
-Creating a new project? Check out the [repo management](repo-management/README.md) documentation for information on how to set your project up.
+Creating a new project? Check out the [repo management](https://github.com/chef/chef-oss-practices/blob/master/repo-management/README.md) documentation for information on how to set your project up.
 
 ## Project Membership
 
-We encourage all contributors to become project members. We aim to grow an active, healthy community of contributors, reviewers, and project owners. Learn about requirements and perks of membership in our [Project Membership](project-membership.md) page.
+We encourage all contributors to become project members. We aim to grow an active, healthy community of contributors, reviewers, and project owners. Learn about requirements and perks of membership in our [Project Membership](https://github.com/chef/chef-oss-practices/blob/master/project-membership.md) page.
 
 ## Table of Contents
-- [README](README.md)
-- [Contributing](CONTRIBUTING.md)
-- [Project Membership](project-membership.md)
-- [Projects List](projects-list.md)
-- [Governance](governance.md)
-- [Developer Certificate of Origin](DCO.md)
+- [README](https://github.com/chef/chef-oss-practices/blob/master/README.md)
+- [Contributing](https://github.com/chef/chef-oss-practices/blob/master/CONTRIBUTING.md)
+- [Project Membership](https://github.com/chef/chef-oss-practices/blob/master/project-membership.md)
+- [Projects List](https://github.com/chef/chef-oss-practices/blob/master/projects-list.md)
+- [Governance](https://github.com/chef/chef-oss-practices/blob/master/governance.md)
+- [Developer Certificate of Origin](https://github.com/chef/chef-oss-practices/blob/master/DCO.md)
 
 ### Code of Conduct
-- [Virtual Spaces Code of Conduct](CODE_OF_CONDUCT.md)
-- [Physical Spaces Code of Conduct](physical-spaces-code-of-conduct.md)
+- [Virtual Spaces Code of Conduct](https://github.com/chef/chef-oss-practices/blob/master/CODE_OF_CONDUCT.md)
+- [Physical Spaces Code of Conduct](https://github.com/chef/chef-oss-practices/blob/master/physical-spaces-code-of-conduct.md)
 
 ### Contributors
-- [Contributor Licenses](./contributors/software-licenses.md)
+- [Contributor Licenses](https://github.com/chef/chef-oss-practices/blob/master/contributors/software-licenses.md)
 
 ### Distributions
-- [Distribution Guidelines](./distributions/distribution-guidelines.md)
-- [Distribution List](./distributions/distribution-list.md)
+- [Distribution Guidelines](https://github.com/chef/chef-oss-practices/blob/master/distributions/distribution-guidelines.md)
+- [Distribution List](https://github.com/chef/chef-oss-practices/blob/master/distributions/distribution-list.md)
 
 **Guide**
-- [README](./contributors/guide/README.md)
-- [Collaborative Development](./contributors/guide/collaborative-dev.md)
-- [Community Expectations](./contributors/guide/community-expectations.md)
-- [Contributor Cheatsheet](./contributors/guide/contributor-cheatsheet.md)
-- [Design Proposals](./contributors/guide/design-proposals.md)
-- [Help Wanted](./contributors/guide/help-wanted.md)
-- [Project Planning](./contributors/guide/project-planning.md)
-- [Pull Requests](./contributors/guide/pull-requests.md)
-- [Ways to Contribute](./contributors/guide/ways-to-contribute.md)
+- [README](https://github.com/chef/chef-oss-practices/blob/master/contributors/guide/README.md)
+- [Collaborative Development](https://github.com/chef/chef-oss-practices/blob/master/contributors/guide/collaborative-dev.md)
+- [Community Expectations](https://github.com/chef/chef-oss-practices/blob/master/contributors/guide/community-expectations.md)
+- [Contributor Cheatsheet](https://github.com/chef/chef-oss-practices/blob/master/contributors/guide/contributor-cheatsheet.md)
+- [Design Proposals](https://github.com/chef/chef-oss-practices/blob/master/contributors/guide/design-proposals.md)
+- [Help Wanted](https://github.com/chef/chef-oss-practices/blob/master/contributors/guide/help-wanted.md)
+- [Project Planning](https://github.com/chef/chef-oss-practices/blob/master/contributors/guide/project-planning.md)
+- [Pull Requests](https://github.com/chef/chef-oss-practices/blob/master/contributors/guide/pull-requests.md)
+- [Ways to Contribute](https://github.com/chef/chef-oss-practices/blob/master/contributors/guide/ways-to-contribute.md)
 
 ### Communication
-- [README](./communication/README.md)
-- [Community Meetings](./communication/community-meetings.md)
-- [Decider](./communication/decider.md)
-- [Triage](./communication/triage.md)
-- [Project End of Life](./communication/project-eol.md)
-- [Community Members in Crises](./communication/community-members-in-crisis.md)
-- [Video Conferencing](./communication/video-conferencing.md)
-- [Support Boundaries](./communication/support-boundaries.md)
-- [Saying No](./communication/saying-no.md)
-- [Communication FAQ](./communication/communication-faq.md)
+- [README](https://github.com/chef/chef-oss-practices/blob/master/communication/README.md)
+- [Community Meetings](https://github.com/chef/chef-oss-practices/blob/master/communication/community-meetings.md)
+- [Decider](https://github.com/chef/chef-oss-practices/blob/master/communication/decider.md)
+- [Triage](https://github.com/chef/chef-oss-practices/blob/master/communication/triage.md)
+- [Project End of Life](https://github.com/chef/chef-oss-practices/blob/master/communication/project-eol.md)
+- [Community Members in Crises](https://github.com/chef/chef-oss-practices/blob/master/communication/community-members-in-crisis.md)
+- [Video Conferencing](https://github.com/chef/chef-oss-practices/blob/master/communication/video-conferencing.md)
+- [Support Boundaries](https://github.com/chef/chef-oss-practices/blob/master/communication/support-boundaries.md)
+- [Saying No](https://github.com/chef/chef-oss-practices/blob/master/communication/saying-no.md)
+- [Communication FAQ](https://github.com/chef/chef-oss-practices/blob/master/communication/communication-faq.md)
 
 ### Repo Management
-- [README](./repo-management/README.md)
-- [Project Setup](./repo-management/project-required-setup.md)
-- [Repo States](./repo-management/repo-states.md)
-- [GitHub Labels](./repo-management/github-labels.md)
+- [README](https://github.com/chef/chef-oss-practices/blob/master/repo-management/README.md)
+- [Project Setup](https://github.com/chef/chef-oss-practices/blob/master/repo-management/project-required-setup.md)
+- [Repo States](https://github.com/chef/chef-oss-practices/blob/master/repo-management/repo-states.md)
+- [GitHub Labels](https://github.com/chef/chef-oss-practices/blob/master/repo-management/github-labels.md)
 
 
 ### Guilds
-- [README](./guilds/README.md)
+- [README](https://github.com/chef/chef-oss-practices/blob/master/guilds/README.md)
 
 ### Checklists
-- [Managing Pull Requests](./checklists/managing-pull-requests.md)
-- [New Projects](./checklists/new-project.md)
+- [Managing Pull Requests](https://github.com/chef/chef-oss-practices/blob/master/checklists/managing-pull-requests.md)
+- [New Projects](https://github.com/chef/chef-oss-practices/blob/master/checklists/new-project.md)


### PR DESCRIPTION
Signed-off-by: Shaun Yap <shaunyap@gmail.com>

<!--- Provide a short summary of your changes in the Title above -->
Changed relative links in the readme to absolute ones

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
We're pulling the markdown file into the developer community site, so relative links will break as we are not creating pages for every markdown file in the repo at the moment. 

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->
this also takes care of this PR
https://github.com/chef/chef-oss-practices/pull/265


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
