### PR TITLE
Move cookstyle and vscode-chef to Chef Infra project

### DIFF
--- a/projects/chef-infra.md
+++ b/projects/chef-infra.md
@@ -43,8 +43,10 @@ Mark Anderson
 - [chef-sugar](https://github.com/chef/chef-sugar)
 - [chef](https://github.com/chef/chef)
 - [cheffish](https://github.com/chef/cheffish)
+- [cookstyle](https://github.com/chef/cookstyle)
 - [ohai](https://github.com/chef/ohai)
 - [proxy_tests](https://github.com/chef/proxy_tests)
+- [vscode-chef](https://github.com/chef/vscode-chef)
 
 ### Project Alums
 

--- a/projects/chef-workstation.md
+++ b/projects/chef-workstation.md
@@ -32,15 +32,17 @@ Robb Kidd
   - Github: [robbkidd](https://github.com/robbkidd)
   - Slack: @robbkidd
 
-Tim Smith
-  - Github: [tas50](https://github.com/tas50)
-  - Slack: @tas50
-
 Tyler Ball
   - Github: [tyler-ball](https://github.com/tyler-ball)
   - Slack: @tball
 
 #### Project Reviewers
+
+#### Project Alums
+
+Tim Smith
+  - Github: [tas50](https://github.com/tas50)
+  - Slack: @tas50
 
 ### Project Repositories
 
@@ -51,8 +53,6 @@ Tyler Ball
 - [chef-workstation-app](https://github.com/chef/chef-workstation-app)
 - [chef-workstation](https://github.com/chef/chef-workstation)
 - [cookbook-omnifetch](https://github.com/chef/cookbook-omnifetch)
-- [cookstyle](https://github.com/chef/cookstyle)
 - [go-chef](https://github.com/chef/go-chef)
 - [go-libs](https://github.com/chef/go-libs)
 - [stove](https://github.com/chef/stove)
-- [vscode-chef](https://github.com/chef/vscode-chef)


### PR DESCRIPTION
Both of these projects are driven by changes to the Chef Infra project and it's appropriate that reviews of changes be done by the Chef Infra team and not the Chef Workstation team. This also adds myself as a Workstation alum per our process.

Signed-off-by: Tim Smith <tsmith@chef.io>