### PR TITLE
Move former Automate team members to Alumni section.

### DIFF
--- a/projects/chef-automate.md
+++ b/projects/chef-automate.md
@@ -20,8 +20,6 @@ deployment toplogies supported by `chef-automate deploy`.
 
 #### Project Approvers
 
-- Salim Afiune
-  - GitHub: [afiune](https://github.com/afiune)
 - Tara Black
   - GitHub: [tarablack01](https://github.com/tarablack01)
 - Scott Christopherson
@@ -38,8 +36,6 @@ deployment toplogies supported by `chef-automate deploy`.
   - GitHub: [lancefw](https://github.com/lancefw)
 - Brenna Hewer-Darroch
   - GitHub: [bcmdarroch](https://github.com/bcmdarroch)
-- Pete Higgins
-  - GitHub: [phiggins](https://github.com/phiggins)
 - Shadae Holmes
   - GitHub: [shadae](https://github.com/shadae)
 - Blake Johnson
@@ -58,8 +54,6 @@ deployment toplogies supported by `chef-automate deploy`.
   - GitHub: [srenatus](https://github.com/srenatus)
 - Michael Sorens
   - GitHub: [msorens](https://github.com/msorens)
-- Maggie Walker
-  - GitHub: [magwalk](https://github.com/magwalk)
 
 #### Project Reviewers
 
@@ -77,3 +71,12 @@ deployment toplogies supported by `chef-automate deploy`.
 ### Project Repositories
 
 - [automate](https://github.com/chef/automate)
+
+### Project Alums
+
+- Pete Higgins
+  - GitHub: [phiggins](https://github.com/phiggins)
+- Salim Afiune
+  - GitHub: [afiune](https://github.com/afiune)
+- Maggie Walker
+  - GitHub: [magwalk](https://github.com/magwalk)


### PR DESCRIPTION
Add an alumni section to the Automate document and move myself and some former employees there.

## Description
The list of project members is not accurate in its current form.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
