### PR TITLE
Update the Chef Infra project

### DIFF
--- a/projects/chef-infra.md
+++ b/projects/chef-infra.md
@@ -4,7 +4,7 @@ The Chef Infra project includes chef-client and all directly related projects.
 
 **Slack Channel** #chef-infra-dev
 
-**Triage Schedule**: TBD
+**Triage Schedule**: Mondays at 10:00am PST
 
 ### Project Members
 
@@ -14,6 +14,10 @@ Bryan McLellan
   - Github: [btm](https://github.com/btm)
   - Slack: @btm
 
+Josh O'Brien
+  - Github: [OBrienCommaJosh](https://github.com/OBrienCommaJosh)
+  - Slack: @job
+
 Lamont Granquist
   - Github: [lamont-granquist](https://github.com/lamont-granquist)
   - Slack: @lamont
@@ -22,15 +26,7 @@ Tim Smith
   - Github: [tas50](https://github.com/tas50)
   - Slack: @tas50
 
-Josh O'Brien
-  - Github: [OBrienCommaJosh](https://github.com/OBrienCommaJosh)
-  - Slack: @job
-  
 #### Project Approvers
-
-Ryan Davis
-  - Github: [zenspider](https://github.com/zenspider)
-  - Slack: @Ryan Davis
 
 Robb Kidd
   - Github: [robbkidd](https://github.com/robbkidd)
@@ -54,7 +50,6 @@ John McCrae
   - Github: [johnmccrae](http://github.com/johnmccrae)
   - Slack: @John McCrae
 
-
 ### Project Repositories
 
 - [bft](https://github.com/chef/bft)
@@ -75,29 +70,21 @@ Adam Jacob
   - Github: [adamhjk](https://github.com/adamhjk)
   - Slack: @adam
 
-Thom May
-  - Github: [thommay](https://github.com/thommay)
-  - Slack: @thom
-
 Adam Leff
   - Github: [adamleff]((https://github.com/adamleff))
   - Slack: @adamleff
 
-Noah Kantrowitz
-  - Github: [coderanger](https://github.com/coderanger)
-  - Slack: @coderanger
+AJ Christensen
+  - Github: [fujin](https://github.com/fujin)
+  - Slack: @fujin
 
-Seth Thomas
-  - Github: [cheeseplus](https://github.com/cheeseplus)
-  - Slack: @cheeseplus
+Amy Aronsohn
+  - Github: [OnlyHaveCans](https://github.com/OnlyHaveCans)
+  - Slack: @onlyhavecans
 
 Daniel DeLeo
   - Github: [danielsdeleo](https://github.com/danielsdeleo)
   - Slack: @kallistec
-
-AJ Christensen
-  - Github: [fujin](https://github.com/fujin)
-  - Slack: @fujin
 
 Jay Mundrawala
   - Github: [jaym](https://github.com/jaym)
@@ -111,13 +98,45 @@ Jon Cowie
   - Github: [jonlives](https://github.com/jonlives)
   - Slack: @jonlives
 
+Josh Hudson
+  - Github: [itmustbejj](https://github.com/itmustbejj)
+  - Slack: @jhudson
+
 Joshua Timberman
   - Github: [jtimberman](https://github.com/jtimberman)
   - Slack: @jtimberman
 
+Kartik Cating-Subramanian
+  - Github: [ksubrama](https://github.com/ksubrama)
+  - Slack: @ksubrama
+
+Matt Wrock
+  - Github: [mwrock](https://github.com/mwrock)
+  - Slack: @mwrock
+
+Mike Dodge
+  - Github: [mikedodge04](https://github.com/mikedodge04)
+  - Slack: @mikedodge04
+
+Noah Kantrowitz
+  - Github: [coderanger](https://github.com/coderanger)
+  - Slack: @coderanger
+
 Ranjib Dey
   - Github: [ranjib](https://github.com/ranjib)
   - Slack: @cha0s
+
+Ryan Davis
+  - Github: [zenspider](https://github.com/zenspider)
+  - Slack: @Ryan Davis
+
+Salim Alam
+  - Github: [chefsalim](https://github.com/chefsalim)
+  - Slack: @Salim Alam
+
+Seth Thomas
+  - Github: [cheeseplus](https://github.com/cheeseplus)
+  - Slack: @cheeseplus
 
 Steven Murawksi
   - Github: [smurawski](https://github.com/smurawski)
@@ -131,6 +150,10 @@ Stuart Preston
   - Github: [stuartpreston](https://github.com/stuartpreston)
   - Slack: @stuart
 
+Thom May
+  - Github: [thommay](https://github.com/thommay)
+  - Slack: @thom
+
 Tom Duffield
   - Github: [tduffield](https://github.com/tduffield)
   - Slack: @tduffield
@@ -138,27 +161,3 @@ Tom Duffield
 Tyler Ball
   - Github: [tyler-ball](https://github.com/tyler-ball)
   - Slack: @tball
-
-Josh Hudson
-  - Github: [itmustbejj](https://github.com/itmustbejj)
-  - Slack: @jhudson
-
-Kartik Cating-Subramanian
-  - Github: [ksubrama](https://github.com/ksubrama)
-  - Slack: @ksubrama
-
-Salim Alam
-  - Github: [chefsalim](https://github.com/chefsalim)
-  - Slack: @Salim Alam
-
-Matt Wrock
-  - Github: [mwrock](https://github.com/mwrock)
-  - Slack: @mwrock
-
-Mike Dodge
-  - Github: [mikedodge04](https://github.com/mikedodge04)
-  - Slack: @mikedodge04
-
-Amy Aronsohn
-  - Github: [OnlyHaveCans](https://github.com/OnlyHaveCans)
-  - Slack: @onlyhavecans


### PR DESCRIPTION
Add our triage schedule
Move Ryan to alum
A->Z entries

Signed-off-by: Tim Smith <tsmith@chef.io>