### PR TITLE
Move Robb to alumns in supermarket and remove chef-community-zero

### DIFF
--- a/projects/supermarket.md
+++ b/projects/supermarket.md
@@ -12,10 +12,6 @@ The Supermarket project includes Supermarket and all related repositories.
 
 #### Project Approvers
 
-Robb Kidd
-  - Github: [robbkidd](https://github.com/robbkidd)
-  - Slack: @robbkidd
-
 #### Project Reviewers
 
 Marc Paradise
@@ -28,13 +24,16 @@ Will Fisher
 
 #### Project Alums
 
+Robb Kidd
+  - Github: [robbkidd](https://github.com/robbkidd)
+  - Slack: @robbkidd
+
 Tyler Ball
   - Github: [tyler-ball](https://github.com/tyler-ball)
   - Slack: @tball
-
+ 
 ### Project Repositories
 
 - [supermarket](https://github.com/chef/supermarket)
 - [supermarket-omnibus-cookbook](https://github.com/chef-cookbooks/supermarket-omnibus-cookbook)
 - [cookbook-quality-metrics](https://github.com/chef-cookbooks/cookbook-quality-metrics)
-- [chef-community-zero](https://github.com/chef/chef-community-zero)


### PR DESCRIPTION
Chef community zero is dead now that stove is deprecated.

Paging @robbkidd 

Signed-off-by: Tim Smith <tsmith@chef.io>
