### PR TITLE
Remove the cookbook-quality-metrics repo

### DIFF
--- a/projects/supermarket.md
+++ b/projects/supermarket.md
@@ -65,4 +65,3 @@ Tyler Ball
 
 - [supermarket](https://github.com/chef/supermarket)
 - [supermarket-omnibus-cookbook](https://github.com/chef-cookbooks/supermarket-omnibus-cookbook)
-- [cookbook-quality-metrics](https://github.com/chef-cookbooks/cookbook-quality-metrics)


### PR DESCRIPTION
This is in the boneyard now. It's dead.

Signed-off-by: Tim Smith <tsmith@chef.io>