### PR TITLE
Centralized Per-Project Contributor files

### DIFF
--- a/contributors/projects/chef-server.md
+++ b/contributors/projects/chef-server.md
@@ -1,0 +1,24 @@
+# Contributing to Chef Server
+
+Thank you for your interest in Chef Server!  We use **GitHub Issues** for issue tracking and contributions:
+
+1. Reporting an issue or making a feature request
+2. Submitting patches for new features or bug fixes
+
+We follow a process used by other Chef products: <https://github.com/chef/chef/blob/main/CONTRIBUTING.md>
+
+## Submitting Patches
+
+All patches should be submitted as GitHub pull requests:
+
+1. Make changes on a branch, ensuring to add the [Developer Certificate of Origin sign-off](https://github.com/chef/chef/blob/main/CONTRIBUTING.md#developer-certification-of-origin-dco) to your commits.
+
+2. Consult the CODE_REVIEW_CHECKLIST.md to see what code reviewers will be looking for.
+
+3. Create a GitHub Pull Request.
+
+4. If you are a Chef Software employee, submit an ad-hoc chef-server-12 build for your branch and post a link to in the pull request. For non-Chef Software employees, your job will be submitted for you by one of the reviewers.
+
+5. Respond to code review comments to improve the code until it is ready to merge.
+
+5. Rebase your branch on `main` to pick up any changes that have landed since your patch was opened and merge it!  (If you don't have commit access, a maintainer will merge it for you after code review is complete).

--- a/contributors/projects/chef-server.md
+++ b/contributors/projects/chef-server.md
@@ -1,3 +1,6 @@
+> [!WARNING]
+> This page in the Chef Open Source Software Practices repository is currently undergoing content review.
+
 # Contributing to Chef Server
 
 Thank you for your interest in Chef Server!  We use **GitHub Issues** for issue tracking and contributions:

--- a/contributors/projects/chef.md
+++ b/contributors/projects/chef.md
@@ -1,0 +1,182 @@
+# Contributing to Chef Projects
+
+We're glad you want to contribute to a Chef project! This document will help answer common questions you may have during your first contribution.
+
+## Submitting Issues
+
+Not every contribution comes in the form of code. Submitting, confirming, and triaging issues is an important task for any project. At Chef we use GitHub to track all project issues.
+
+If you are familiar with Chef and know the component that is causing you a problem, you can file an issue in the corresponding GitHub project. All of our Open Source Software can be found in our [Chef GitHub organization](https://github.com/chef/). All projects include GitHub issue templates to help gather information needed for a thorough review.
+
+We ask you not to submit security concerns via GitHub. For details on submitting potential security issues please see <https://www.chef.io/security/>
+
+In addition to GitHub issues, we also utilize a feedback site that helps our product team track and rank feature requests. If you have a feature request, this is an excellent place to start <https://www.chef.io/feedback/>
+
+## Contribution Process
+
+We have a 3 step process for contributions:
+
+1. Commit changes to a git branch, making sure to sign-off those changes for the [Developer Certificate of Origin](#developer-certification-of-origin-dco).
+2. Create a GitHub Pull Request for your change, following the instructions in the pull request template.
+3. Perform a [Code Review](#code-review-process) with the project maintainers on the pull request.
+
+### Branching
+
+When creating pull requests, you will need to push your branch to your own fork of the repo.
+
+For internal teams:
+* Prefix your initials such as `tp/branch-name` to help delineate at a glance who created the branch.
+* Please include a ticket number for JIRA (e.g., `tp/infc-399-branch-short-desc`) if possible to help JIRA link back to the branch and subsequent PR.
+
+### Pull Request Requirements
+
+Chef Projects are built to last. We strive to ensure high quality throughout the experience. In order to ensure this, we require that all pull requests to Chef projects meet these specifications:
+
+1. **Tests:** To ensure high quality code and protect against future regressions, we require all the code in Chef Projects to have at least unit test coverage. We use [RSpec](http://rspec.info/) for unit testing.
+2. **Green CI Tests:** We use [Buildkite](https://buildkite.com/chef-oss) to test all pull requests. We require these test runs to succeed on every pull request before being merged.
+3. **Rebase** `git rebase {target-branch}` prior to merging. :no_entry: Avoid pulling in the target branch, as mixing and matching with `rebase` can easily make a mess of the commit history :sob:... You will likely need to `git push -f {remote-branch}` after rebasing.
+
+### Code Review Process
+
+Code review takes place in GitHub pull requests. See [this article](https://help.github.com/articles/about-pull-requests/) if you're not familiar with GitHub Pull Requests.
+
+Once you open a pull request, project maintainers will review your code and respond to your pull request with any feedback they might have. The process at this point is as follows:
+
+1. Two or more members of the owners, approvers, or reviewers groups must approve your PR. See the [Chef Infra OSS Project](https://github.com/chef/chef-oss-practices/blob/main/projects/chef-infra.md) for a list of all members.
+2. Your change will be merged into the project's `main` branch
+3. Our Expeditor bot will automatically increment the version and update the project's changelog with your contribution. For projects that ship as a package, Expeditor will kick off a build which will publish the package to the project's `current` channel.
+
+If you would like to learn about when your code will be available in a release of Chef, read more about [Chef Release Cycles](#release-cycles).
+
+### Developer Certification of Origin (DCO)
+
+Licensing is very important to open source projects. It helps ensure the software continues to be available under the terms that the author desired.
+
+Chef uses [the Apache 2.0 license](https://github.com/chef/chef/blob/main/LICENSE) to strike a balance between open contribution and allowing you to use the software however you would like to.
+
+The license tells you what rights you have that are provided by the copyright holder. It is important that the contributor fully understands what rights they are licensing and agrees to them. Sometimes the copyright holder isn't the contributor, such as when the contributor is doing work on behalf of a company.
+
+To make a good faith effort to ensure these criteria are met, Chef requires the Developer Certificate of Origin (DCO) process to be followed.
+
+The DCO is an attestation attached to every contribution made by every developer. In the commit message of the contribution, the developer simply adds a Signed-off-by statement and thereby agrees to the DCO, which you can find below or at <http://developercertificate.org/>.
+
+```
+Developer's Certificate of Origin 1.1
+
+By making a contribution to this project, I certify that:
+
+(a) The contribution was created in whole or in part by me and I
+    have the right to submit it under the open source license
+    indicated in the file; or
+
+(b) The contribution is based upon previous work that, to the
+    best of my knowledge, is covered under an appropriate open
+    source license and I have the right under that license to
+    submit that work with modifications, whether created in whole
+    or in part by me, under the same open source license (unless
+    I am permitted to submit under a different license), as
+    Indicated in the file; or
+
+(c) The contribution was provided directly to me by some other
+    person who certified (a), (b) or (c) and I have not modified
+    it.
+
+(d) I understand and agree that this project and the contribution
+    are public and that a record of the contribution (including
+    all personal information I submit with it, including my
+    sign-off) is maintained indefinitely and may be redistributed
+    consistent with this project or the open source license(s)
+    involved.
+```
+
+For more information on the change see the Chef Blog post [Introducing Developer Certificate of Origin](https://blog.chef.io/2016/09/19/introducing-developer-certificate-of-origin/)
+
+#### DCO Sign-Off Methods
+
+The DCO requires a sign-off message in the following format appear on each commit in the pull request:
+
+```
+Signed-off-by: Julia Child <julia.child@progress.com>
+```
+
+The DCO text can either be manually added to your commit body, or you can add either **-s** or **--signoff** to your usual git commit commands. If you are using the GitHub UI to make a change you can add the sign-off message directly to the commit message when creating the pull request. If you forget to add the sign-off you can also amend a previous commit with the sign-off by running **git commit --amend -s**. If you've pushed your changes to GitHub already you'll need to force push your branch after this with **git push -f**.
+
+### Chef Obvious Fix Policy
+
+Small contributions, such as fixing spelling errors, where the content is small enough to not be considered intellectual property, can be submitted without signing the contribution for the DCO.
+
+As a rule of thumb, changes are obvious fixes if they do not introduce any new functionality or creative thinking. Assuming the change does not affect functionality, some common obvious fix examples include the following:
+
+- Spelling / grammar fixes
+- Typo correction, white space and formatting changes
+- Comment clean up
+- Bug fixes that change default return values or error codes stored in constants
+- Adding logging messages or debugging output
+- Changes to 'metadata' files like Gemfile, .gitignore, build scripts, etc.
+- Moving source files from one directory or package to another
+
+**Whenever you invoke the "obvious fix" rule, please say so in your commit message:**
+
+```
+------------------------------------------------------------------------
+commit 370adb3f82d55d912b0cf9c1d1e99b132a8ed3b5
+Author: Julia Child <juliachild@chef.io>
+Date:   Wed Sep 18 11:44:40 2015 -0700
+
+  Fix typo in the README.
+
+  Obvious fix.
+
+------------------------------------------------------------------------
+```
+
+### Gems
+
+When making a PR, if you need to add or remove gems, it should be done using the `--conservative` flag:
+```shell
+gem install [gem_name] --conservative
+gem update [gem_name] --conservative
+```
+
+If your PR includes such an update to `Gemfile.lock`, please include the output of your `gem update` or `gem install` command in the PR.
+
+### Gem Maintenance
+
+At a minimum, once a quarter the maintainers will run a full `bundle update` to update all gems within the limits defined by the `Gemfile`.
+(This should be done preferably **after** minor release for testability)
+
+At least once a year, we will also do a review of the limits in the `Gemfile`.
+
+### Merging
+1. Use `[Squash and Merge]` and edit down the commit history to a clear description of what the changes were with the "TL;DR" bits in the first 60 characters of the commit message. Update the PR title if necessary.
+2. Add the changes to the [Pending Release Notes](https://github.com/chef/chef/wiki) for the appropriate release version.
+
+## Release Cycles
+
+Our primary shipping vehicle is operating system specific packages that includes all the requirements of Chef. The packages are built with our [Omnibus](https://github.com/chef/omnibus) packing project.
+
+We also release our software as gems to [Rubygems](https://rubygems.org/) but we strongly recommend using Chef packages since they are the only combination of native libraries & gems required by Chef that we test thoroughly.
+
+Our version numbering roughly follows [Semantic Versioning](http://semver.org/) standard. Our standard version numbers look like X.Y.Z which mean:
+
+- X is a major release, which may not be fully compatible with prior major releases
+- Y is a minor release, which adds both new features and bug fixes
+- Z is a patch release, which adds just bug fixes
+
+After shipping a release of Chef we bump the `Minor` version by one to start development of the next minor release. All merges to `main` trigger an increment of the `Patch` version, and a build through our internal testing pipeline. We do a `Minor` release approximately every month, which consist of shipping one of the already auto-incremented and tested `Patch` versions. For example after shipping 12.10.24, we incremented Chef to 12.11.0\. From there 18 commits where merged bringing the version to 12.11.18, which we shipped as an omnibus package.
+
+Announcements of releases are made to the [chef mailing list](https://discourse.chef.io/c/chef-release) when they are available and are mirrored to the #announcements channel on the [Chef Community Slack](https://community-slack.chef.io/).
+
+## Chef Community
+
+Chef is made possible by a strong community of developers and system administrators. If you have any questions or if you would like to get involved in the Chef community you can check out:
+
+- [Chef Mailing List](https://discourse.chef.io/)
+- [Chef Community Slack](https://community-slack.chef.io/)
+
+Also here are some additional pointers to some awesome Chef content:
+
+- [Chef Docs](https://docs.chef.io/)
+- [Learn Chef](https://learn.chef.io/)
+- [Chef Software Inc. Website](https://www.chef.io/)
+- [Chef Project Website](https://www.chef.sh/)

--- a/contributors/projects/chef.md
+++ b/contributors/projects/chef.md
@@ -1,3 +1,6 @@
+> [!WARNING]
+> This page in the Chef Open Source Software Practices repository is currently undergoing content review.
+
 # Contributing to Chef Projects
 
 We're glad you want to contribute to a Chef project! This document will help answer common questions you may have during your first contribution.

--- a/contributors/projects/habitat.md
+++ b/contributors/projects/habitat.md
@@ -1,3 +1,6 @@
+> [!WARNING]
+> This page in the Chef Open Source Software Practices repository is currently undergoing content review.
+
 # Contributing to Habitat
 
 Thank you for your interest in contributing to Habitat! There are many ways to contribute, and we appreciate all of them.

--- a/contributors/projects/habitat.md
+++ b/contributors/projects/habitat.md
@@ -1,0 +1,217 @@
+# Contributing to Habitat
+
+Thank you for your interest in contributing to Habitat! There are many ways to contribute, and we appreciate all of them.
+
+You are currently in the core Habitat repo, which is primarily written in Rust code and holds the core functionality of the Core Habitat, Habitat Builder Web Application, Habitat Builder, and Documentation. If you are interested in contributing a new plan to core plans (which is a great way to get started as a new contributor!), check out the [core-plans repo](https://github.com/habitat-sh/core-plans) instead.
+
+If you have questions, join the [Habitat Slack Channel](http://slack.habitat.sh) to talk directly to the community and core maintainers. All experience levels of questions are welcome in the general channel.
+
+As a reminder, all participants are expected to follow the [Code of Conduct](https://github.com/habitat-sh/habitat/blob/master/CODE_OF_CONDUCT.md).
+
+* [Support Channels](#support-channels)
+* [Feature Requests](#feature-requests)
+* [Bug Reports](#bug-reports)
+* [Report a security vulnerability](#report-a-security-vulnerability)
+* [Pull Requests](#pull-requests)
+* [Writing Documentation and blogs](#writing-documentation-and-blogs)
+* [Issue Triage](#issue-triage)
+* [Related Articles](#related-articles)
+* [Development priniciples for working on Habitat](#development-principles-for-working-on-habitat)
+* [Workstation Setup](#workstation-setup)
+* [Writing new features](#writing-new-features)
+* [Signing Your Commits](#signing-your-commits)
+* [Pull Request Review and Merge Automation](#pull-request-review-and-merge-automation)
+* [Delegating pull request merge access](#delegating-pull-request-merge-access)
+* [Running a Builder service cluster locally](#running-a-builder-service-cluster-locally)
+* [Documentation for Rust Crates](#documentation-for-rust-crates)
+
+# Support Channels
+
+Whether you are a user or contributor, official support channels include:
+
+* GitHub issues: https://github.com/habitat-sh/habitat/issues
+* Slack: http://slack.habitat.sh
+
+Before opening a new issue or submitting a new pull request, it's helpful to search the project - it's likely that another user has already reported the issue you're facing, or it's a known issue that we're already aware of.
+
+# Feature Requests
+
+To request a change to the way that Habitat works, please [open an issue](https://github.com/habitat-sh/habitat/issues).
+
+# Bug Reports
+
+Bugs are a reality in software. We can't fix what we don't know about, so please report liberally. If you're not sure if something's a bug or not, feel free to file a bug anyway.
+
+If you believe your bug represents a security issue for Habitat users, please follow our instructions for [reporting a security vulnerability.](#report-a-security-vulnerability)
+
+If you have the chance, before reporting a bug please [search existing issues](https://github.com/habitat-sh/habitat/issues), as it's possible someone has already reported your error.
+
+Opening an issue is as easy as following [this link](https://github.com/habitat-sh/habitat/issues/new) and filling out the form with as much information as you have. It is not necessary to follow the template exactly.
+
+# Report a security vulnerability
+
+Safety is one of the core principles of Habitat, and to that end, we would like to ensure that Habitat has a secure implementation. Thank you for taking the time to responsibly disclose any issues you find.
+
+All security bugs in the distribution should be reported by email to security@habitat.sh. This list is delivered to a small security team. Your email will be acknowledged within 24 hours, and you'll receive a more detailed response to your email within 48 hours indicating the next steps in handling your report.
+
+This email address receives a large amount of spam, so be sure to use a descriptive subject line to avoid having your report be missed. After the initial reply to your report, the security team will endeavor to keep you informed of the progress being made towards a fix and full announcement.
+
+If you have not received a reply to your email within 48 hours, or have not heard from the security team for the past five days, there are a few steps you can take:
+
+* Contact the current security coordinator (Jamie Winsor) directly.
+* Contact the back-up contacts (Fletcher Nichol, Tasha Drew) directly.
+* Post on the [slack channel](http://slack.habitat.sh) requesting an update.
+
+Please note that the discussion forums and slack channel are public areas. When escalating in these venues, please do not discuss your issue. Simply say that you're trying to get a hold of someone from the security team.
+
+# Pull Requests
+
+Pull requests are the primary mechanism we use to write Habitat. GitHub itself has some great documentation on using [the Pull Request feature](https://help.github.com/articles/about-pull-requests/). We use the "fork and pull" model [described here](https://help.github.com/articles/about-collaborative-development-models/), where contributors push changes to their personal fork and create pull requests to bring those changes into the source repository.
+
+Please make pull requests against the `master` branch.
+
+# Writing Documentation and Blogs
+
+Documentation improvements are very welcome.
+
+To find documentation-related issues, [search by the A-Documentation label](https://github.com/habitat-sh/habitat/issues?q=is%3Aissue+is%3Aopen+label%3AA-documentation).
+
+Blogs from community members are also very welcome. You can open a pull request to submit a blog for the website by [following these instructions](https://github.com/habitat-sh/habitat/tree/master/www/source/blog).
+
+# Issue Triage
+
+The Habitat core team does issue triage every Tuesday, at 10am Pacific time. A link to a public video is made available in the #general channel of Slack when triage occurs, and a recording is shared afterwards on the [Habitat youtube channel](https://www.youtube.com/channel/UC0wJZeP2dfPZaDUPgvpVpSg).
+
+You can also help triage by using the following labeling system adopted by the Habitat core team:
+
+| *TAGS Groups*                     |               Meaning                             |
+|:----------------------------------|:--------------------------------------------------|
+| *AREA TAGS* Prefix "A-"           | What part of the codebase does the issue refer to.|
+| *CATEGORIZATION TAGS* Prefix "C-" | What type of work does the issue refer to.        |
+| *EFFORT TAGS* Prefix "E-"         | Should a contributor undertake, what is the estimated effort level. |
+| *LANGUAGE TAGS* Prefix "L-"       | Pretty straightforward right? What language the work will involve.  |
+| *STATUS TAGS* Prefix "S-"         | The current status of an issue or pull request.   |
+| *PLATFORM TAGS* Prefix "P-"       | Issue is in regards to specific platform.         |
+
+[Read more about issue triage here.](https://www.habitat.sh/blog/community/)
+
+# Related Articles
+* [Current Habitat Maintainers](https://github.com/habitat-sh/habitat/blob/master/MAINTAINERS.md)
+* [Maintainers Policy, how to become a Maintainers](https://github.com/habitat-sh/habitat/blob/master/maintenance-policy.md)
+* [ReadMe](https://github.com/habitat-sh/habitat/blob/master/README.md)
+* [CLI UX Principes](https://github.com/habitat-sh/habitat/blob/master/UX_PRINCIPLES.md)
+* [Habitat Main Website: Browse docs, do a tutorial, check out Builder](https://www.habitat.sh/)
+
+## Development principles for working on Habitat
+
+1. The principle of least abstraction. When possible, we use the tooling that is closest to the native
+tooling for the platform, and provide as little abstraction as necessary. When we do choose an abstraction,
+we choose one - and we make it the one that is most user-serviceable.
+1. Keep it light. The runtime component of Habitat is used as a process Supervisor - it needs to stay lean. No run-times.
+1. Convention over configuration, with reasonable defaults. Where possible, we remove the need to configure things
+by having a convention cover it. When we do need to configure things, we set reasonable defaults.
+1. Call things what they are.
+1. It has to feel great to the end user. If it doesn't feel great, it's a bug.
+1. Write documentation as you go. Internal and external.
+
+## Workstation Setup
+
+See [BUILDING.md](BUILDING.md) for platform specific info on getting your workstation configured to contribute.
+
+## Writing new features
+
+1. Start a new feature branch
+1. Open a terminal and run `make shell`
+1. Change directory to a component `cd components/x`
+1. Build with `cargo build` or `cargo test`
+1. You can use `cargo run -- foobar` to pass options to the built binary
+1. Sign and commit your change
+1. Push your feature branch to GitHub, and create a Pull Request
+
+## Signing Your Commits
+
+This project utilizes a Developer Certificate of Origin (DCO) to ensure that each commit was written by the
+author or that the author has the appropriate rights necessary to contribute the change.  The project
+utilizes [Developer Certificate of Origin, Version 1.1](http://developercertificate.org/)
+
+```
+Developer Certificate of Origin
+Version 1.1
+
+Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
+660 York Street, Suite 102,
+San Francisco, CA 94110 USA
+
+Everyone is permitted to copy and distribute verbatim copies of this
+license document, but changing it is not allowed.
+
+
+Developer's Certificate of Origin 1.1
+
+By making a contribution to this project, I certify that:
+
+(a) The contribution was created in whole or in part by me and I
+    have the right to submit it under the open source license
+    indicated in the file; or
+
+(b) The contribution is based upon previous work that, to the best
+    of my knowledge, is covered under an appropriate open source
+    license and I have the right under that license to submit that
+    work with modifications, whether created in whole or in part
+    by me, under the same open source license (unless I am
+    permitted to submit under a different license), as indicated
+    in the file; or
+
+(c) The contribution was provided directly to me by some other
+    person who certified (a), (b) or (c) and I have not modified
+    it.
+
+(d) I understand and agree that this project and the contribution
+    are public and that a record of the contribution (including all
+    personal information I submit with it, including my sign-off) is
+    maintained indefinitely and may be redistributed consistent with
+    this project or the open source license(s) involved.
+```
+
+Each commit must include a DCO which looks like this
+
+`Signed-off-by: Joe Smith <joe.smith@email.com>`
+
+The project requires that the name used is your real name.  Neither anonymous contributors nor those
+utilizing pseudonyms will be accepted.
+
+Git makes it easy to add this line to your commit messages.  Make sure the `user.name` and
+`user.email` are set in your git configs.  Use `-s` or `--signoff` to add the Signed-off-by line to
+the end of the commit message.
+
+## Pull Request Review and Merge Automation
+
+Habitat uses several bots to automate the review and merging of pull requests. Messages to and from the bots are brokered via the account @thesentinel. First, we use Facebook's [mention bot](https://github.com/facebook/mention-bot) to identify potential reviewers for a pull request based on the `blame` information in the relevant diff. @thesentinels can also receive
+incoming commands from reviewers to approve PRs. These commands are routed to a [homu](https://github.com/barosl/homu) bot that will automatically merge a PR when sufficient reviewers have provided a +1 (or r+ in homu terminology).
+
+
+## Delegating pull request merge access
+
+A Habitat core maintainer can delegate pull request merge access to a contributor via
+
+	@thesentinels delegate=username
+
+If you've been given approval to merge, you can do so by appending a comment to the pull request containing the following text:
+
+	@thesentinels r+
+
+Note: **do not** click the Merge Pull Request button if it's enabled.
+
+
+## Running a Builder service cluster locally
+
+A service cluster can be started in your host machine with `make bldr-run`. The public API will be available on port 9636 and the admin API will be available on port 8080. The depot web site will be available on port 3000.
+
+Please refer to the detailed setup instructions in the [builder repo](https://github.com/habitat-sh/builder)'s [DEVELOPING.md](https://github.com/habitat-sh/builder/blob/master/DEVELOPING.md) file for how to bring up a service cluster, as there are currently some manual steps involved.
+
+
+## Documentation for Rust Crates
+
+The Rust crates also have their own internal developer documentation. From the root of the project, type `make docs` to build the internal Rust documentation.
+
+Run `make serve-docs` to run a small web server that exposes the documentation on port `9633`. You can then read the docs at `http://<DOCKER_HOST>:9633/` (with working JavaScript-based search).

--- a/contributors/projects/inspec.md
+++ b/contributors/projects/inspec.md
@@ -1,0 +1,168 @@
+# Contributing to InSpec
+
+We are glad you want to contribute to InSpec! This document will help answer common questions you may have during your first contribution.
+
+As a reminder, all participants are expected to follow the [Code of Conduct](https://github.com/inspec/inspec/blob/main/CODE_OF_CONDUCT.md).
+
+## Submitting Issues
+
+We utilize **Github Issues** for issue tracking and contributions. You can contribute in two ways:
+
+1. Reporting an issue or making a feature request [here](https://github.com/chef/inspec/issues/new).
+2. Adding features or fixing bugs yourself and contributing your code to InSpec.
+
+We ask you not to submit security concerns via Github. For details on submitting potential security issues please see <https://www.chef.io/security/>
+
+## Contribution Process
+
+We have a 3 step process for contributions:
+
+1. Commit changes to a git branch, making sure to sign-off those changes for the [Developer Certificate of Origin](#developer-certification-of-origin-dco).
+2. Create a Github Pull Request for your change, following the instructions in the pull request template.
+3. Perform a [Code Review](#code-review-process) with the project maintainers on the pull request.
+
+### Pull Request Requirements
+
+Chef Projects are built to last. We strive to ensure high quality throughout the experience. In order to ensure this, we require that all pull requests to Chef projects meet these specifications:
+
+1. **Tests:** To ensure high quality code and protect against future regressions, we require all the code in Chef Projects to have at least unit test coverage. See the [test/unit](https://github.com/inspec/inspec/tree/main/test/unit)
+directory for the existing tests and use ```bundle exec rake test``` to run them. It should be good to know InSpec uses [minitest](https://github.com/seattlerb/minitest) as a testing framework.
+2. **Green CI Tests:** We use [Travis CI](https://travis-ci.org/) and/or [AppVeyor](https://www.appveyor.com/) CI systems to test all pull requests. We require these test runs to succeed on every pull request before being merged.
+3. **Up-to-date Documentation:**  Every code change should be reflected in an update for our [documentation](https://github.com/inspec/inspec/tree/main/docs-chef-io). We expect PRs to update the documentation with the code change.
+
+In addition to this it would be nice to include the description of the problem you are solving
+  with your change. You can use [Issue Template](https://github.com/inspec/inspec/tree/main/ISSUE_TEMPLATE.md) in the description section
+  of the pull request.
+
+### Code Review Process
+
+Code review takes place in Github pull requests. See [this article](https://help.github.com/articles/about-pull-requests/) if you're not familiar with Github Pull Requests.
+
+Once you open a pull request, project maintainers will review your code and respond to your pull request with any feedback they might have. The process at this point is as follows:
+
+1. Two thumbs-up (:+1:) are required from project maintainers. See the master maintainers document for InSpec projects at <https://github.com/chef/inspec/blob/master/MAINTAINERS.md>.
+2. When ready, your pull request will be merged into `master`, we may require you to rebase your PR to the latest `master`.
+3. Once the PR is merged, you will be included in `CHANGELOG.md`.
+
+If you would like to learn about when your code will be available in a release of InSpec, read more about [InSpec Release Cycles](#release-cycles).
+
+### Developer Certification of Origin (DCO)
+
+Licensing is very important to open source projects. It helps ensure the software continues to be available under the terms that the author desired.
+
+Chef uses [the Apache 2.0 license](https://github.com/chef/chef/blob/master/LICENSE) to strike a balance between open contribution and allowing you to use the software however you would like to.
+
+The license tells you what rights you have that are provided by the copyright holder. It is important that the contributor fully understands what rights they are licensing and agrees to them. Sometimes the copyright holder isn't the contributor, such as when the contributor is doing work on behalf of a company.
+
+To make a good faith effort to ensure these criteria are met, Chef requires the Developer Certificate of Origin (DCO) process to be followed.
+
+The DCO is an attestation attached to every contribution made by every developer. In the commit message of the contribution, the developer simply adds a Signed-off-by statement and thereby agrees to the DCO, which you can find below or at <http://developercertificate.org/>.
+
+```
+Developer's Certificate of Origin 1.1
+
+By making a contribution to this project, I certify that:
+
+(a) The contribution was created in whole or in part by me and I
+    have the right to submit it under the open source license
+    indicated in the file; or
+
+(b) The contribution is based upon previous work that, to the
+    best of my knowledge, is covered under an appropriate open
+    source license and I have the right under that license to
+    submit that work with modifications, whether created in whole
+    or in part by me, under the same open source license (unless
+    I am permitted to submit under a different license), as
+    Indicated in the file; or
+
+(c) The contribution was provided directly to me by some other
+    person who certified (a), (b) or (c) and I have not modified
+    it.
+
+(d) I understand and agree that this project and the contribution
+    are public and that a record of the contribution (including
+    all personal information I submit with it, including my
+    sign-off) is maintained indefinitely and may be redistributed
+    consistent with this project or the open source license(s)
+    involved.
+```
+
+For more information on the change see the Chef Blog post [Introducing Developer Certificate of Origin](https://blog.chef.io/2016/09/19/introducing-developer-certificate-of-origin/)
+
+#### DCO Sign-Off Methods
+
+The DCO requires a sign-off message in the following format appear on each commit in the pull request:
+
+```
+Signed-off-by: Julia Child <juliachild@chef.io>
+```
+
+The DCO text can either be manually added to your commit body, or you can add either **-s** or **--signoff** to your usual git commit commands. If you forget to add the sign-off you can also amend a previous commit with the sign-off by running **git commit --amend -s**. If you've pushed your changes to Github already you'll need to force push your branch after this with **git push -f**.
+
+### Obvious Fix Policy
+
+Small contributions, such as fixing spelling errors, where the content is small enough to not be considered intellectual property, can be submitted without signing the contribution for the DCO.
+
+As a rule of thumb, changes are obvious fixes if they do not introduce any new functionality or creative thinking. Assuming the change does not affect functionality, some common obvious fix examples include the following:
+
+- Spelling / grammar fixes
+- Typo correction, white space and formatting changes
+- Comment clean up
+- Bug fixes that change default return values or error codes stored in constants
+- Adding logging messages or debugging output
+- Changes to 'metadata' files like Gemfile, .gitignore, build scripts, etc.
+- Moving source files from one directory or package to another
+
+**Whenever you invoke the "obvious fix" rule, please say so in your commit message:**
+
+```
+------------------------------------------------------------------------
+commit 370adb3f82d55d912b0cf9c1d1e99b132a8ed3b5
+Author: Julia Child <juliachild@chef.io>
+Date:   Wed Sep 18 11:44:40 2015 -0700
+
+  Fix typo in the README.
+
+  Obvious fix.
+
+------------------------------------------------------------------------
+```
+
+## Release Cycles
+
+### Release Formats
+
+Our primary shipping vehicle is operating system specific packages that includes all the requirements of InSpec. We call these Omnibus packages, and they are available from [Chef Downloads](https://www.chef.io/downloads/tools/inspec). InSpec is also bundled with recent Chef Infra Client and Chef Workstation toolkits.
+
+InSpec is also available as a [Docker image](https://hub.docker.com/r/chef/inspec) and a [Habitat package](https://bldr.habitat.sh/#/pkgs/chef/inspec/latest).
+
+Finally, we also release our software as gems to [Rubygems](https://rubygems.org/) but we strongly recommend using one of the previously packages to ensure a smooth experience.
+
+### Release Timing
+
+We typically aim to make a release every Thursday; however, if there are no changes, the release will be skipped. Releases may also be delayed due to holidays, staffing constraints, or technical problems.
+
+### Versioning
+
+This information is provided for context only.  Contributors are not expected to manage the version number of InSpec - the InSpec team and the CI system will handle any version changes needed.
+
+Our version numbering roughly follows [Semantic Versioning](http://semver.org/) standard. Our standard version numbers look like X.Y.Z which mean:
+
+- X is a major release, which may not be fully compatible with prior major releases
+- Y is a minor release, which adds new features and may include bug fixes
+- Z is a patch release, which adds just bug fixes
+
+After shipping a release of InSpec we bump at least the `patch` version by one to start development of the next release. We do a release approximately every week. Announcements of releases are made to the [InSpec mailing list](https://discourse.chef.io/c/chef-release) when they are available.
+
+## InSpec Community
+
+InSpec is made possible by a strong community of developers, system administrators, auditor and security experts. If you have any questions or if you would like to get involved in the InSpec community you can check out:
+
+- [InSpec Mailing List](https://discourse.chef.io/c/inspec)
+- [Chef Community Slack](https://community-slack.chef.io/)
+
+Also here are some additional pointers to some awesome Chef content:
+
+- [InSpec Docs](https://docs/chef.io/inspec/)
+- [Learn Chef](https://learn.chef.io/)
+- [Chef Website](https://www.chef.io/)

--- a/contributors/projects/inspec.md
+++ b/contributors/projects/inspec.md
@@ -1,3 +1,6 @@
+> [!WARNING]
+> This page in the Chef Open Source Software Practices repository is currently undergoing content review.
+
 # Contributing to InSpec
 
 We are glad you want to contribute to InSpec! This document will help answer common questions you may have during your first contribution.


### PR DESCRIPTION
This is part of the 2025 Repository Standardization Initiative.

Since there is wide variance across the repos as to the contents of the CONTRIBUTING.md files, we decided:
 * that each repo's CONTRIBUTING.md should simply contain a link to somewhere more authoritative
 * that the authoritative copy of the contributing guide should be in one governance repo, chef-oss-practices, rather than in many different project repos (such as chef/chef, etc). Thus chef/chef will refer to chef-oss-practices.

Based on this, we will move the contents of each of the major projects' CONTRIBUTING into this repo, and replace the disparate copies with links to this repo.

Like all content in this governance repo, the policies contained in the documents are currently under review.
